### PR TITLE
Add "muted" attribute to video element

### DIFF
--- a/inc/class-gif2html5.php
+++ b/inc/class-gif2html5.php
@@ -567,7 +567,7 @@ class Gif2Html5 {
 		$div_container = '<div class="' . esc_attr( $this->gif2html5_class ) . '-container">';
 
 		return $div_container . '<video '
-		. trim( $this->attributes_string( $attributes ) . ' autoplay loop' )
+		. trim( $this->attributes_string( $attributes ) . ' autoplay loop muted' )
 		. '>' . join( '', $sources ) . $fallback . '</video></div>';
 	}
 


### PR DESCRIPTION
Adding the "muted" attribute seems to prevent browsers from popping up notifications that "audio is playing".

See #56.