### PR TITLE
Cache the reults of autoplay support test in localStorage

### DIFF
--- a/js/src/gif2html5.js
+++ b/js/src/gif2html5.js
@@ -2,14 +2,19 @@
 	$(document).ready(function() {
 		var videos = $('video.gif2html5-video');
 		var videoHandler = VideoHandler(videos);
-
 		videoHandler.handleError();
 		videoHandler.handleMobile();
 
 		(function() {
+			var gif2html5Support = JSON.parse(localStorage.getItem('gif2html5-support')) || {};
+			var returnFalse = function(){ return false; }
 
 			function indicateSupport(type, test) {
-				if (test) {
+				if (typeof gif2html5Support[type] === 'undefined') {
+					gif2html5Support[type] = !!(test)();
+					localStorage.setItem('gif2html5-support',JSON.stringify(gif2html5Support));
+				} 
+				if (gif2html5Support[type]) {
 					document.documentElement.className += ' gif2html5-support-' + type;
 				} else {
 					document.documentElement.className += ' no-gif2html5-support-' + type;
@@ -39,7 +44,11 @@
 				return bool;
 			})();
 
-			indicateSupport('video', videoSupport);
+			function testVideoSupport() {
+				return videoSupport;
+			}
+			
+			indicateSupport('video', testVideoSupport);
 
 			function indicateAutoplaySupport(test) {
 				indicateSupport('videoautoplay', test);
@@ -53,14 +62,14 @@
 			function testAutoplay(arg) {
 				clearTimeout(timeout);
 				elem.removeEventListener('playing', testAutoplay, false);
-				indicateAutoplaySupport(arg && arg.type === 'playing' || elem.currentTime !== 0);
+				indicateAutoplaySupport(function(){return arg && arg.type === 'playing' || elem.currentTime !== 0});
 				elem.parentNode.removeChild(elem);
 			}
 
 			//skip the test if video itself, or the autoplay
 			//element on it isn't supported
-			if (!videoSupport || !('autoplay' in elem)) {
-				indicateAutoplaySupport(false);
+			if (!gif2html5Support['video'] || !('autoplay' in elem)) {
+				indicateAutoplaySupport(returnFalse);
 				return;
 			}
 
@@ -76,12 +85,12 @@
 					elem.src = 'data:video/mp4;base64,AAAAHGZ0eXBtcDQyAAAAAG1wNDJpc29tYXZjMQAAAz5tb292AAAAbG12aGQAAAAAzaNacc2jWnEAAV+QAAFfkAABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAGGlvZHMAAAAAEICAgAcAT////3//AAACQ3RyYWsAAABcdGtoZAAAAAHNo1pxzaNacQAAAAEAAAAAAAFfkAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAEAAAABAAAAAAAd9tZGlhAAAAIG1kaGQAAAAAzaNacc2jWnEAAV+QAAFfkFXEAAAAAAAhaGRscgAAAAAAAAAAdmlkZQAAAAAAAAAAAAAAAAAAAAGWbWluZgAAABR2bWhkAAAAAQAAAAAAAAAAAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADHVybCAAAAABAAABVnN0YmwAAACpc3RzZAAAAAAAAAABAAAAmWF2YzEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAEAAQAEgAAABIAAAAAAAAAAEOSlZUL0FWQyBDb2RpbmcAAAAAAAAAAAAAAAAAAAAAAAAY//8AAAAxYXZjQwH0AAr/4QAZZ/QACq609NQYBBkAAAMAAQAAAwAKjxImoAEABWjOAa8gAAAAEmNvbHJuY2xjAAYAAQAGAAAAGHN0dHMAAAAAAAAAAQAAAAUAAEZQAAAAKHN0c3oAAAAAAAAAAAAAAAUAAAIqAAAACAAAAAgAAAAIAAAACAAAAChzdHNjAAAAAAAAAAIAAAABAAAABAAAAAEAAAACAAAAAQAAAAEAAAAYc3RjbwAAAAAAAAACAAADYgAABaQAAAAUc3RzcwAAAAAAAAABAAAAAQAAABFzZHRwAAAAAAREREREAAAAb3VkdGEAAABnbWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcgAAAAAAAAAAAAAAAAAAAAA6aWxzdAAAADKpdG9vAAAAKmRhdGEAAAABAAAAAEhhbmRCcmFrZSAwLjkuOCAyMDEyMDcxODAwAAACUm1kYXQAAAHkBgX/4NxF6b3m2Ui3lizYINkj7u94MjY0IC0gY29yZSAxMjAgLSBILjI2NC9NUEVHLTQgQVZDIGNvZGVjIC0gQ29weWxlZnQgMjAwMy0yMDExIC0gaHR0cDovL3d3dy52aWRlb2xhbi5vcmcveDI2NC5odG1sIC0gb3B0aW9uczogY2FiYWM9MCByZWY9MSBkZWJsb2NrPTE6MDowIGFuYWx5c2U9MHgxOjAgbWU9ZXNhIHN1Ym1lPTkgcHN5PTAgbWl4ZWRfcmVmPTAgbWVfcmFuZ2U9NCBjaHJvbWFfbWU9MSB0cmVsbGlzPTAgOHg4ZGN0PTAgY3FtPTAgZGVhZHpvbmU9MjEsMTEgZmFzdF9wc2tpcD0wIGNocm9tYV9xcF9vZmZzZXQ9MCB0aHJlYWRzPTYgc2xpY2VkX3RocmVhZHM9MCBucj0wIGRlY2ltYXRlPTEgaW50ZXJsYWNlZD0wIGJsdXJheV9jb21wYXQ9MCBjb25zdHJhaW5lZF9pbnRyYT0wIGJmcmFtZXM9MCB3ZWlnaHRwPTAga2V5aW50PTUwIGtleWludF9taW49NSBzY2VuZWN1dD00MCBpbnRyYV9yZWZyZXNoPTAgcmM9Y3FwIG1idHJlZT0wIHFwPTAAgAAAAD5liISscR8A+E4ACAACFoAAITAAAgsAAPgYCoKgoC+L4vi+KAvi+L4YfAEAACMzgABF9AAEUGUgABDJiXnf4AAAAARBmiKUAAAABEGaQpQAAAAEQZpilAAAAARBmoKU';
 				}
 				else {
-					indicateAutoplaySupport(false);
+					indicateAutoplaySupport(returnFalse);
 					return;
 				}
 			}
 			catch (e) {
-				indicateAutoplaySupport(false);
+				indicateAutoplaySupport(returnFalse);
 				return;
 			}
 


### PR DESCRIPTION
Ensures that the potentially expensive video autoplay test is only run on the initial page load but saving the results in local storage, and checking to see if a saved value exists before running the tests.

Since the autoplay detection test involves adding and removing elements from the DOM, this improves time to DOM stability on subsequent views.

See #75.