### PR TITLE
Add filter inside `get_element_attributes` method.

### DIFF
--- a/inc/class-gif2html5.php
+++ b/inc/class-gif2html5.php
@@ -552,7 +552,8 @@ class Gif2Html5 {
 	public function img_to_video_element( $id, $img_element ) {
 		$attributes = $this->get_element_attributes(
 			$img_element,
-			array( 'width', 'height', 'class', 'src', 'alt', 'srcset' )
+			array( 'width', 'height', 'class', 'src', 'alt', 'srcset' ),
+			$id
 		);
 
 		return $this->get_video_element(
@@ -623,7 +624,7 @@ class Gif2Html5 {
 		. '>' . join( '', $sources ) . $fallback . '</video></div>';
 	}
 
-	private function get_element_attributes( $element_html, $att_names ) {
+	private function get_element_attributes( $element_html, $att_names, $id = null ) {
 		$html = '<html><body>' . $element_html . '</body></html>';
 		$doc = new DomDocument();
 		$doc->loadHtml( $html );
@@ -642,7 +643,7 @@ class Gif2Html5 {
 				$attributes[ $att_name ] = $att_value;
 			}
 		}
-		return $attributes;
+		return apply_filters( 'gif2html5_element_attributes', $attributes, $id );
 	}
 
 	private function attributes_string( $attributes ) {

--- a/tests/test-gif2html5.php
+++ b/tests/test-gif2html5.php
@@ -391,6 +391,15 @@ class Test_Gif2Html5 extends WP_UnitTestCase {
 		$this->assertEquals( $snapshot, 'http://assets.cloudfront.net/folder/snapshot.png' );
 	}
 
+	function test_element_attributes_filter() {
+		add_filter( 'gif2html5_element_attributes', function( $attributes, $attachment_id ) {
+			$attributes['src'] = 'http://photon.dev/filtered/image.gif';
+			return $attributes;
+		}, 10, 2);
+		$html = $this->get_img_to_video_html();
+		$this->assertContains( 'data-gif="http://photon.dev/filtered/image.gif"', $html );
+	}
+
 	function test_webhook_callback_unsets_pending_conversion_flag() {
 
 		Gif2Html5()->set_conversion_response_pending( $this->gif_id );


### PR DESCRIPTION
This filter is applied to the attributes as retrieved from the original `<img>` element, so that individual attributes can be filtered. A use case would be transforming image urls to Photon urls, so that images can be proxied and resized on the fly.

This filter gets the entire `attributes` array ( 'width', 'height', 'class', 'src', 'alt', 'srcset' ) as its argument and can modify any piece of it. Also passed in is the attachment ID, for additional context.

There was already an existing filter in the `get_video_element_attributes` method which can be used to filter the poster image URL, but that's too late to modify the fallback object, which is where I imagine this would be most useful - because a gif might be uploaded at a very large size, but only need to be displayed very small.

See #83.