### PR TITLE
Change video behavior on mobile

### DIFF
--- a/js/src/video-handler.js
+++ b/js/src/video-handler.js
@@ -38,19 +38,15 @@ var VideoHandler = (function($) {
 				$videoContainer.addClass('loaded');
 				var $video = $videoContainer.find('video');
 
-				if (navigator.userAgent.match(/(iPad|iPhone|iPod)/g)) {
-					if ($video.hasClass('gif2html5-extremely-large-gif')) {
-						$videoContainer.addClass('playable')
-							.on('click', function(evt) {
-								evt.stopPropagation();
-								$video.get(0).play();
-							}
-						);
-					} else {
-						fallbackGif($video);
-					}
+				if ($video.hasClass('gif2html5-extremely-large-gif')) {
+					$videoContainer.addClass('playable')
+						.on('click', function(evt) {
+							evt.stopPropagation();
+							fallbackGif($video);
+						}
+					);
 				} else {
-					$video.get(0).play();
+					fallbackGif($video);
 				}
 			}
 		}


### PR DESCRIPTION
Because the video.play() method is no longer working on Android, this
changes the behavior of gif2html5 on all devices that don't support
video or autoplay to be something more like the existing iOS behavior:

- All gifs less than 1MB in size will 'auto-play' when the image element
  scrolls into view - meaning that the poster image will be replaced by
  the animated gif.
- Extremely large gif will display a play button. Clicking the overlay
  with the play button will replace the placeholder image with the gif.